### PR TITLE
Add U2S board support

### DIFF
--- a/LUFA/Drivers/Board/AVR8/U2S/Board.h
+++ b/LUFA/Drivers/Board/AVR8/U2S/Board.h
@@ -1,0 +1,82 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2013.
+
+  dean [at] fourwalledcubicle [dot] com
+           www.lufa-lib.org
+*/
+
+/*
+  Copyright 2013  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting
+  documentation, and that the name of the author not be used in
+  advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  The author disclaims all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/** \file
+ *  \brief Board specific information header for the U2S.
+ *  \copydetails Group_BoardInfo_U2S
+ *
+ *  \note This file should not be included directly. It is automatically included as needed by the Board driver
+ *        dispatch header located in LUFA/Drivers/Board/Board.h.
+ */
+
+/** \ingroup Group_BoardInfo
+ *  \defgroup Group_BoardInfo_U2S
+ *  \brief Board specific information header for the U2S.
+ *
+ *  Board specific information header for the U2S (http://sites.google.com/site/megau2s/).
+ *
+ *  @{
+ */
+
+#ifndef __BOARD_U2S__
+#define __BOARD_U2S__
+
+	/* Includes: */
+		#include "../../../../Common/Common.h"
+		#include "../../Buttons.h"
+		#include "../../LEDs.h"
+
+	/* Enable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			extern "C" {
+		#endif
+
+	/* Preprocessor Checks: */
+		#if !defined(__INCLUDE_FROM_BOARD_H)
+			#error Do not include this file directly. Include LUFA/Drivers/Board/Board.h instead.
+		#endif
+
+	/* Public Interface - May be used in end-application: */
+		/* Macros: */
+			/** Indicates the board has a hardware Buttons mounted. */
+			#define BOARD_HAS_BUTTONS
+
+			/** Indicates the board has a hardware LEDs mounted. */
+			#define BOARD_HAS_LEDS
+
+	/* Disable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			}
+		#endif
+
+#endif
+
+/** @} */
+

--- a/LUFA/Drivers/Board/AVR8/U2S/Buttons.h
+++ b/LUFA/Drivers/Board/AVR8/U2S/Buttons.h
@@ -1,0 +1,103 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2013.
+
+  dean [at] fourwalledcubicle [dot] com
+           www.lufa-lib.org
+*/
+
+/*
+  Copyright 2013  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting
+  documentation, and that the name of the author not be used in
+  advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  The author disclaims all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/** \file
+ *  \brief Board specific Buttons driver header for the Mattairtech JM-DB-U2.
+ *  \copydetails Group_Buttons_U2S
+ *
+ *  \note This file should not be included directly. It is automatically included as needed by the Buttons driver
+ *        dispatch header located in LUFA/Drivers/Board/Buttons.h.
+ */
+
+/** \ingroup Group_Buttons
+ *  \defgroup Group_Buttons_U2S U2S
+ *  \brief Board specific Buttons driver header for the U2S.
+ *
+ *  Board specific Buttons driver header for the U2S (http://sites.google.com/site/megau2s/).
+ *
+ *  <table>
+ *    <tr><th>Name</th><th>Info</th><th>Active Level</th><th>Port Pin</th></tr>
+ *    <tr><td>BUTTONS_BUTTON1</td><td>HWB Button</td><td>Low</td><td>PORTC.4</td></tr>
+ *  </table>
+ *
+ *  @{
+ */
+
+#ifndef __BUTTONS_U2S__
+#define __BUTTONS_U2S__
+
+	/* Includes: */
+		#include "../../../../Common/Common.h"
+
+	/* Enable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			extern "C" {
+		#endif
+
+	/* Preprocessor Checks: */
+		#if !defined(__INCLUDE_FROM_BUTTONS_H)
+			#error Do not include this file directly. Include LUFA/Drivers/Board/Buttons.h instead.
+		#endif
+
+	/* Public Interface - May be used in end-application: */
+		/* Macros: */
+			/** Button mask for the first button on the board. */
+			#define BUTTONS_BUTTON1      (1 << 4)
+
+		/* Inline Functions: */
+		#if !defined(__DOXYGEN__)
+			static inline void Buttons_Init(void)
+			{
+				DDRC  &= ~BUTTONS_BUTTON1;
+				PORTC |=  BUTTONS_BUTTON1;
+			}
+
+			static inline void Buttons_Disable(void)
+			{
+				DDRC  &= ~BUTTONS_BUTTON1;
+				PORTC &= ~BUTTONS_BUTTON1;
+			}
+
+			static inline uint8_t Buttons_GetStatus(void) ATTR_WARN_UNUSED_RESULT;
+			static inline uint8_t Buttons_GetStatus(void)
+			{
+				return ((PINC & BUTTONS_BUTTON1) ^ BUTTONS_BUTTON1);
+			}
+		#endif
+
+	/* Disable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			}
+		#endif
+
+#endif
+
+/** @} */
+

--- a/LUFA/Drivers/Board/AVR8/U2S/LEDs.h
+++ b/LUFA/Drivers/Board/AVR8/U2S/LEDs.h
@@ -1,0 +1,135 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2013.
+
+  dean [at] fourwalledcubicle [dot] com
+           www.lufa-lib.org
+*/
+
+/*
+  Copyright 2013  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting
+  documentation, and that the name of the author not be used in
+  advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  The author disclaims all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/** \file
+ *  \brief Board specific LED driver header for the Tempusdictum Benito.
+ *  \copydetails Group_LEDs_U2S
+ *
+ *  \note This file should not be included directly. It is automatically included as needed by the LEDs driver
+ *        dispatch header located in LUFA/Drivers/Board/LEDs.h.
+ */
+
+/** \ingroup Group_LEDs
+ *  \defgroup Group_LEDs_U2S U2S
+ *  \brief Board specific LED driver header for the U2S.
+ *
+ *  Board specific LED driver header for the U2S (http://sites.google.com/site/megau2s/).
+ *
+ *  <table>
+ *    <tr><th>Name</th><th>Color</th><th>Info</th><th>Active Level</th><th>Port Pin</th></tr>
+ *    <tr><td>LEDS_LED1</td><td>Red</td><td>General Indicator</td><td>Low</td><td>PORTC.2</td></tr>
+ *  </table>
+ *
+ *  @{
+ */
+
+#ifndef __LEDS_U2S__
+#define __LEDS_U2S__
+
+	/* Includes: */
+		#include "../../../../Common/Common.h"
+
+	/* Enable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			extern "C" {
+		#endif
+
+	/* Preprocessor Checks: */
+		#if !defined(__INCLUDE_FROM_LEDS_H)
+			#error Do not include this file directly. Include LUFA/Drivers/Board/LEDS.h instead.
+		#endif
+
+	/* Public Interface - May be used in end-application: */
+		/* Macros: */
+			/** LED mask for the first LED on the board. */
+			#define LEDS_LED1        (1 << 2)
+
+			/** LED mask for all the LEDs on the board. */
+			#define LEDS_ALL_LEDS    LEDS_LED1
+
+			/** LED mask for none of the board LEDs. */
+			#define LEDS_NO_LEDS     0
+
+		/* Inline Functions: */
+		#if !defined(__DOXYGEN__)
+			static inline void LEDs_Init(void)
+			{
+				DDRC  |= LEDS_ALL_LEDS;
+				PORTC |= LEDS_ALL_LEDS;
+			}
+
+			static inline void LEDs_Disable(void)
+			{
+				DDRC  &= ~LEDS_ALL_LEDS;
+				PORTC &= ~LEDS_ALL_LEDS;
+			}
+
+			static inline void LEDs_TurnOnLEDs(const uint8_t LEDMask)
+			{
+				PORTC &= ~LEDMask;
+			}
+
+			static inline void LEDs_TurnOffLEDs(const uint8_t LEDMask)
+			{
+				PORTC |= LEDMask;
+			}
+
+			static inline void LEDs_SetAllLEDs(const uint8_t LEDMask)
+			{
+				PORTC = ((PORTC | LEDS_ALL_LEDS) & ~LEDMask);
+			}
+
+			static inline void LEDs_ChangeLEDs(const uint8_t LEDMask,
+			                                   const uint8_t ActiveMask)
+			{
+				PORTC = ((PORTC | LEDMask) & ~ActiveMask);
+			}
+
+			static inline void LEDs_ToggleLEDs(const uint8_t LEDMask)
+			{
+				PINC  = LEDMask;
+			}
+
+			static inline uint8_t LEDs_GetLEDs(void) ATTR_WARN_UNUSED_RESULT;
+			static inline uint8_t LEDs_GetLEDs(void)
+			{
+				return (~PORTC & LEDS_ALL_LEDS);
+			}
+		#endif
+
+	/* Disable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			}
+		#endif
+
+#endif
+
+/** @} */
+

--- a/LUFA/Drivers/Board/Board.h
+++ b/LUFA/Drivers/Board/Board.h
@@ -151,6 +151,8 @@
 			#include "AVR8/STANGE_ISP/Board.h"
 		#elif (BOARD == BOARD_C3_XPLAINED)
 			#include "XMEGA/C3_XPLAINED/Board.h"
+		#elif (BOARD == BOARD_U2S)
+			#include "AVR8/U2S/Board.h"
 		#else
 			#include "Board/Board.h"
 		#endif

--- a/LUFA/Drivers/Board/Buttons.h
+++ b/LUFA/Drivers/Board/Buttons.h
@@ -157,6 +157,8 @@
 			#include "AVR8/STANGE_ISP/Buttons.h"
 		#elif (BOARD == BOARD_C3_XPLAINED)
 			#include "XMEGA/C3_XPLAINED/Buttons.h"
+		#elif (BOARD == BOARD_U2S)
+			#include "AVR8/U2S/Buttons.h"
 		#else
 			#include "Board/Buttons.h"
 		#endif

--- a/LUFA/Drivers/Board/LEDs.h
+++ b/LUFA/Drivers/Board/LEDs.h
@@ -201,6 +201,8 @@
 			#include "AVR8/STANGE_ISP/LEDs.h"
 		#elif (BOARD == BOARD_C3_XPLAINED)
 			#include "XMEGA/C3_XPLAINED/LEDs.h"
+		#elif (BOARD == BOARD_U2S)
+			#include "AVR8/U2S/LEDs.h"
 		#else
 			#include "Board/LEDs.h"
 		#endif

--- a/Projects/AVRISP-MKII/Config/AppConfig.h
+++ b/Projects/AVRISP-MKII/Config/AppConfig.h
@@ -46,7 +46,11 @@
 	#define AUX_LINE_PORT              PORTB
 	#define AUX_LINE_PIN               PINB
 	#define AUX_LINE_DDR               DDRB
-	#define AUX_LINE_MASK              (1 << 4)
+  #if (BOARD == BOARD_U2S)
+	#define AUX_LINE_MASK              (1 << 0)
+  #else
+  #define AUX_LINE_MASK              (1 << 4)
+  #endif
 
 	#define ENABLE_ISP_PROTOCOL
 	#define ENABLE_XPROG_PROTOCOL


### PR DESCRIPTION
Includes board definition files and patch for AVRISPMKII to move the
reset line for pin compatibility.
http://sites.google.com/site/megau2s/
