### PR TITLE
Replace remaining MIDI interface numbers with enums.

### DIFF
--- a/Demos/Device/ClassDriver/AudioInput/Descriptors.c
+++ b/Demos/Device/ClassDriver/AudioInput/Descriptors.c
@@ -113,7 +113,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			                             sizeof(USB_Audio_Descriptor_OutputTerminal_t)),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_InputTerminal =

--- a/Demos/Device/ClassDriver/AudioOutput/Descriptors.c
+++ b/Demos/Device/ClassDriver/AudioOutput/Descriptors.c
@@ -113,7 +113,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			                             sizeof(USB_Audio_Descriptor_OutputTerminal_t)),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_InputTerminal =

--- a/Demos/Device/ClassDriver/MIDI/Descriptors.c
+++ b/Demos/Device/ClassDriver/MIDI/Descriptors.c
@@ -90,7 +90,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 		{
 			.Header                   = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
 
-			.InterfaceNumber          = INTERFACE_ID_MidiAudioControl,
+			.InterfaceNumber          = INTERFACE_ID_AudioControl,
 			.AlternateSetting         = 0,
 
 			.TotalEndpoints           = 0,
@@ -111,14 +111,14 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.TotalLength              = sizeof(USB_Audio_Descriptor_Interface_AC_t),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_StreamInterface =
 		{
 			.Header                   = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
 
-			.InterfaceNumber          = INTERFACE_ID_MidiAudioStreaming,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 			.AlternateSetting         = 0,
 
 			.TotalEndpoints           = 2,

--- a/Demos/Device/ClassDriver/MIDI/Descriptors.h
+++ b/Demos/Device/ClassDriver/MIDI/Descriptors.h
@@ -83,8 +83,8 @@
 		 */
 		enum InterfaceDescriptors_t
 		{
-			INTERFACE_ID_MidiAudioControl   = 0, /**< MIDI audio control interface descriptor ID */
-			INTERFACE_ID_MidiAudioStreaming = 1, /**< MIDI audio streaming interface descriptor ID */
+			INTERFACE_ID_AudioControl = 0, /**< Audio control interface descriptor ID */
+			INTERFACE_ID_AudioStream  = 1, /**< Audio streaming interface descriptor ID */
 		};
 
 		/** Enum for the device string descriptor IDs within the device. Each string descriptor should

--- a/Demos/Device/ClassDriver/MIDI/MIDI.c
+++ b/Demos/Device/ClassDriver/MIDI/MIDI.c
@@ -44,7 +44,7 @@ USB_ClassInfo_MIDI_Device_t Keyboard_MIDI_Interface =
 	{
 		.Config =
 			{
-				.StreamingInterfaceNumber = INTERFACE_ID_MidiAudioStreaming,
+				.StreamingInterfaceNumber = INTERFACE_ID_AudioStream,
 				.DataINEndpoint           =
 					{
 						.Address          = MIDI_STREAM_IN_EPADDR,

--- a/Demos/Device/LowLevel/AudioInput/Descriptors.c
+++ b/Demos/Device/LowLevel/AudioInput/Descriptors.c
@@ -113,7 +113,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			                             sizeof(USB_Audio_Descriptor_OutputTerminal_t)),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_InputTerminal =

--- a/Demos/Device/LowLevel/AudioOutput/Descriptors.c
+++ b/Demos/Device/LowLevel/AudioOutput/Descriptors.c
@@ -113,7 +113,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			                             sizeof(USB_Audio_Descriptor_OutputTerminal_t)),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_InputTerminal =

--- a/Demos/Device/LowLevel/MIDI/Descriptors.c
+++ b/Demos/Device/LowLevel/MIDI/Descriptors.c
@@ -111,7 +111,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.TotalLength              = sizeof(USB_Audio_Descriptor_Interface_AC_t),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_StreamInterface =

--- a/Projects/MIDIToneGenerator/Descriptors.c
+++ b/Projects/MIDIToneGenerator/Descriptors.c
@@ -111,7 +111,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
 			.TotalLength              = sizeof(USB_Audio_Descriptor_Interface_AC_t),
 
 			.InCollection             = 1,
-			.InterfaceNumber          = 1,
+			.InterfaceNumber          = INTERFACE_ID_AudioStream,
 		},
 
 	.Audio_StreamInterface =


### PR DESCRIPTION
This concludes the interface numbers to enums refactoring.
