### PR TITLE
AVR8: Add option to keep 3.3V regulator enabled

### DIFF
--- a/LUFA/DoxygenPages/ChangeLog.txt
+++ b/LUFA/DoxygenPages/ChangeLog.txt
@@ -11,6 +11,7 @@
   *  - Library Applications:
   *   - Added new Bulk Vendor low level device demo
   *   - Added new libUSB host Python and NodeJS application examples for the class driver GenericHID demo (thanks to Laszlo Monda)
+  *   - Added new AVR8 USB option to keep 3.3V regulator enabled
   *
   *  <b>Changed:</b>
   *  - Library Applications:

--- a/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.c
+++ b/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.c
@@ -112,7 +112,8 @@ void USB_Disable(void)
 	if (!(USB_Options & USB_OPT_MANUAL_PLL))
 	  USB_PLL_Off();
 
-	USB_REG_Off();
+	if (!(USB_Options & USB_OPT_REG_KEEP_ENABLED))
+	  USB_REG_Off();
 
 	#if defined(USB_SERIES_4_AVR) || defined(USB_SERIES_6_AVR) || defined(USB_SERIES_7_AVR)
 	USB_OTGPAD_Off();

--- a/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.h
+++ b/LUFA/Drivers/USB/Core/AVR8/USBController_AVR8.h
@@ -133,6 +133,14 @@
 			 */
 			#define USB_OPT_REG_ENABLED                (0 << 1)
 
+			/** Option mask for \ref USB_Init() to keep regulator enabled at all times. Indicates that \ref USB_Disable()
+			 *  should not disable the regulator as it would otherwise. Has no effect if regulator is disabled using
+			 *  \ref USB_OPT_REG_DISABLED.
+			 *
+			 *  \note See USB AVR data sheet for more information on the internal pad regulator.
+			 */
+			#define USB_OPT_REG_KEEP_ENABLED           (1 << 3)
+
 			/** Manual PLL control option mask for \ref USB_Init(). This indicates to the library that the user application
 			 *  will take full responsibility for controlling the AVR's PLL (used to generate the high frequency clock
 			 *  that the USB controller requires) and ensuring that it is locked at the correct frequency for USB operations.


### PR DESCRIPTION
The documentation contains [sample code on how to restart into the bootloader](http://www.fourwalledcubicle.com/files/LUFA/Doc/130901/html/_page__software_bootloader_start.html). In the process of preparing for the reset, USB is disabled using “USB_Disable()”. For hardware making use of the AVR8's internal 3.3V regulator that call would also disable the regulator, resetting the processor immediately rather than setting the boot key and letting the watchdog reset the processor.

This patch adds a new flag to be given to “USB_Init()” or to be defined in “USE_STATIC_OPTIONS” telling “USB_Disable()” to keep the regulator enabled.

On November 1st, 2013 this issue was already [mentioned on the mailing list](https://groups.google.com/d/msg/lufa-support/uwrFpRQpJzU/e9I6UK5jMJQJ), but no fix came from that discussion.
