### PR TITLE
Get rid of the redundant ATTR_NEVER_INLINE macro which translated to the...

### DIFF
--- a/Bootloaders/MassStorage/Lib/VirtualFAT.h
+++ b/Bootloaders/MassStorage/Lib/VirtualFAT.h
@@ -274,10 +274,10 @@
 
 	/* Function Prototypes: */
 		#if defined(INCLUDE_FROM_VIRTUAL_FAT_C)
-			static uint8_t ReadEEPROMByte(const uint8_t* const Address) ATTR_NEVER_INLINE;
+			static uint8_t ReadEEPROMByte(const uint8_t* const Address) ATTR_NO_INLINE;
 
 			static void WriteEEPROMByte(uint8_t* const Address,
-			                            const uint8_t Data) ATTR_NEVER_INLINE;
+			                            const uint8_t Data) ATTR_NO_INLINE;
 
 			static void UpdateFAT12ClusterEntry(uint8_t* const FATTable,
 			                                    const uint16_t Index,

--- a/LUFA/Common/Attributes.h
+++ b/LUFA/Common/Attributes.h
@@ -90,11 +90,6 @@
 				 */
 				#define ATTR_NO_INLINE               __attribute__ ((noinline))
 
-				/** Forces the compiler to never inline the specified function. When applied, the given function will be
-				 *  always be called explicitly under all circumstances.
-				 */
-				#define ATTR_NEVER_INLINE            __attribute__ ((noinline))
-
 				/** Forces the compiler to inline the specified function. When applied, the given function will be
 				 *  in-lined under all circumstances.
 				 */


### PR DESCRIPTION
... same as ATTR_NO_INLINE.
