### PR TITLE
Fix missing report IDs in feature reports

### DIFF
--- a/LUFA/Drivers/USB/Class/Device/HIDClassDevice.c
+++ b/LUFA/Drivers/USB/Class/Device/HIDClassDevice.c
@@ -68,6 +68,10 @@ void HID_Device_ProcessControlRequest(USB_ClassInfo_HID_Device_t* const HIDInter
 				Endpoint_SelectEndpoint(ENDPOINT_CONTROLEP);
 
 				Endpoint_ClearSETUP();
+
+				if (ReportID)
+				  Endpoint_Write_8(ReportID);
+
 				Endpoint_Write_Control_Stream_LE(ReportData, ReportSize);
 				Endpoint_ClearOUT();
 			}


### PR DESCRIPTION
G'day mates,

consider a device with multiple reports and thus requiring report IDs for distinction. While the ID is set for input reports this was not the case with feature reports - they lacked the ID and confused the HID parser. The USB-HID spec says an ID has to be sent when using multiple reports without stating an exclusion for feature reports, so seems like a bug to me.

The commit included in this request fixes this issue and makes the device pass the HID-parser.
