### PR TITLE
Fix XMEGA USB prescaler calculation

### DIFF
--- a/LUFA/Drivers/USB/Core/XMEGA/USBController_XMEGA.c
+++ b/LUFA/Drivers/USB/Core/XMEGA/USBController_XMEGA.c
@@ -109,14 +109,24 @@ void USB_Disable(void)
 
 void USB_ResetInterface(void)
 {
+	uint8_t PrescalerNeeded;
+	uint8_t nbit = 0;
+
 	#if defined(USB_DEVICE_OPT_FULLSPEED)
 	if (USB_Options & USB_DEVICE_OPT_LOWSPEED)
-	  CLK.USBCTRL = (((F_USB / 6000000) - 1) << CLK_USBPSDIV_gp);
+	  PrescalerNeeded = F_USB / 6000000;
 	else
-	  CLK.USBCTRL = (((F_USB / 48000000) - 1) << CLK_USBPSDIV_gp);
+	  PrescalerNeeded = F_USB / 48000000;
 	#else
-	CLK.USBCTRL = (((F_USB / 6000000) - 1) << CLK_USBPSDIV_gp);
+	PrescalerNeeded = F_USB / 6000000;
 	#endif
+
+	while (PrescalerNeeded && nbit < 7) {
+		PrescalerNeeded >>= 1;
+		nbit++;
+	}
+
+	CLK.USBCTRL = (nbit - 1) << CLK_USBPSDIV_gp;
 
 	if (USB_Options & USB_OPT_PLLCLKSRC)
 	  CLK.USBCTRL |= (CLK_USBSRC_PLL_gc   | CLK_USBSEN_bm);


### PR DESCRIPTION
The XMEGA USB prescaler calculation for the CLK.USBCTRL register is way off for at least the atxmega128b1/3 (tested), atxmega32c4 and atxmega256a3bu (datasheets). I assume the USB module is quite the same across all XMEGA devices if implemented, so indeed the same prescaler calculation is needed. However, according to the datasheets (e.g. [XMEGA B Manual](http://www.atmel.com/Images/Atmel-8291-8-and-16-bit-AVR-Microcontrollers-XMEGA-B_Manual.pdf), p. 88) the prescaler bits are defined as:

| USBPSDIV[2:0] | Prescaler |
| --- | --- |
| 000 | 1 |
| 001 | 2 |
| 010 | 4 |
| 011 | 8 |
| 100 | 16 |
| 101 | 32 |
| 110 | (reserved) |
| 111 | (reserved) |

While for a prescaler of 1 used for full speed USB with a 48 MHz PLL the previous code was correct, for pretty much any other combination like low speed USB with 6 MHz from the same PLL, it wasn't. For some combinations even the reserved bits 6 and 7 in that register were written, and that can't be right, can it ^^

This commit fixes the calculation and has been confirmed to work correctly with an atxmega128b1.
