### PR TITLE
add parens around args in MIDI_EVENT macro

### DIFF
--- a/LUFA/Drivers/USB/Class/Common/MIDIClassCommon.h
+++ b/LUFA/Drivers/USB/Class/Common/MIDIClassCommon.h
@@ -135,7 +135,7 @@
 		 *
 		 *  \return Constructed MIDI event ID.
 		 */
-		#define MIDI_EVENT(virtualcable, command)  ((virtualcable << 4) | (command >> 4))
+		#define MIDI_EVENT(virtualcable, command)  (((virtualcable) << 4) | ((command) >> 4))
 
 	/* Enums: */
 		/** Enum for the possible MIDI jack types in a MIDI device jack descriptor. */


### PR DESCRIPTION
Yes, this bit me. I had code like the following:

```
switch (b>>4) {
        case 0x8: case 0x9: case 0xa: case 0xb: case 0xe:
            pkt.Event = MIDI_EVENT(0, b & 0xf0);
            bytes_left = 3; break;
            /* ... */
}
```
