### PR TITLE
Fixed typo in micro board definition in Studio

### DIFF
--- a/LUFA/StudioIntegration/lufa_drivers_board_names.xml
+++ b/LUFA/StudioIntegration/lufa_drivers_board_names.xml
@@ -836,7 +836,7 @@
 				<build type="define" name="BOARD" value="BOARD_YUN"/>
 			</module>
 
-			<module type="driver" id="lufa.drivers.board#yun" caption="Board Support - MICRO">
+			<module type="driver" id="lufa.drivers.board#micro" caption="Board Support - MICRO">
 				<build type="doxygen-entry-point" value="Group_BoardInfo_MICRO"/>
 
 				<device-support value="atmega32u4"/>


### PR DESCRIPTION
System was displaying two yun boards in the drop down in ASF Wizard