### PR TITLE
Add DHCP Lease Time to RNDIS Demo

### DIFF
--- a/Demos/Device/ClassDriver/RNDISEthernet/Lib/DHCP.c
+++ b/Demos/Device/ClassDriver/RNDISEthernet/Lib/DHCP.c
@@ -95,11 +95,19 @@ int16_t DHCP_ProcessDHCPPacket(void* IPHeaderInStart,
 																								: DHCP_MESSAGETYPE_ACK;
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_SUBNETMASK;
-				*(DHCPOptionsOUTStart++) = 4;
+				*(DHCPOptionsOUTStart++) = sizeof(IP_Address_t);
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0x00;
+
+				*(DHCPOptionsOUTStart++) = DHCP_OPTION_LEASETIME;
+				*(DHCPOptionsOUTStart++) = sizeof(uint32_t);
+				/* Lease Time 86400s (ONE_DAY) */
+				*(DHCPOptionsOUTStart++) = 0x00;
+				*(DHCPOptionsOUTStart++) = 0x01;
+				*(DHCPOptionsOUTStart++) = 0x51;
+				*(DHCPOptionsOUTStart++) = 0x80;
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_DHCPSERVER;
 				*(DHCPOptionsOUTStart++) = sizeof(IP_Address_t);
@@ -108,7 +116,7 @@ int16_t DHCP_ProcessDHCPPacket(void* IPHeaderInStart,
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_END;
 
-				return (sizeof(DHCP_Header_t) + 12 + sizeof(IP_Address_t));
+				return (sizeof(DHCP_Header_t) + 18 + sizeof(IP_Address_t));
 			}
 		}
 

--- a/Demos/Device/ClassDriver/RNDISEthernet/Lib/DHCP.h
+++ b/Demos/Device/ClassDriver/RNDISEthernet/Lib/DHCP.h
@@ -60,6 +60,9 @@
 		/** DHCP option list entry header, indicating that a subnet mask will follow. */
 		#define DHCP_OPTION_SUBNETMASK    1
 
+		/** DHCP option list entry header, indicating that the Lease Time will follow. */
+		#define DHCP_OPTION_LEASETIME     51
+
 		/** DHCP option list entry header, indicating that the DHCP message type constant will follow. */
 		#define DHCP_OPTION_MESSAGETYPE   53
 

--- a/Demos/Device/LowLevel/RNDISEthernet/Lib/DHCP.c
+++ b/Demos/Device/LowLevel/RNDISEthernet/Lib/DHCP.c
@@ -95,11 +95,19 @@ int16_t DHCP_ProcessDHCPPacket(void* IPHeaderInStart,
 																								: DHCP_MESSAGETYPE_ACK;
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_SUBNETMASK;
-				*(DHCPOptionsOUTStart++) = 4;
+				*(DHCPOptionsOUTStart++) = sizeof(IP_Address_t);
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0xFF;
 				*(DHCPOptionsOUTStart++) = 0x00;
+
+				*(DHCPOptionsOUTStart++) = DHCP_OPTION_LEASETIME;
+				*(DHCPOptionsOUTStart++) = sizeof(uint32_t);
+				/* Lease Time 86400s (ONE_DAY) */
+				*(DHCPOptionsOUTStart++) = 0x00;
+				*(DHCPOptionsOUTStart++) = 0x01;
+				*(DHCPOptionsOUTStart++) = 0x51;
+				*(DHCPOptionsOUTStart++) = 0x80;
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_DHCPSERVER;
 				*(DHCPOptionsOUTStart++) = sizeof(IP_Address_t);
@@ -108,7 +116,7 @@ int16_t DHCP_ProcessDHCPPacket(void* IPHeaderInStart,
 
 				*(DHCPOptionsOUTStart++) = DHCP_OPTION_END;
 
-				return (sizeof(DHCP_Header_t) + 12 + sizeof(IP_Address_t));
+				return (sizeof(DHCP_Header_t) + 18 + sizeof(IP_Address_t));
 			}
 		}
 

--- a/Demos/Device/LowLevel/RNDISEthernet/Lib/DHCP.h
+++ b/Demos/Device/LowLevel/RNDISEthernet/Lib/DHCP.h
@@ -60,6 +60,9 @@
 		/** DHCP option list entry header, indicating that a subnet mask will follow. */
 		#define DHCP_OPTION_SUBNETMASK    1
 
+		/** DHCP option list entry header, indicating that the Lease Time will follow. */
+		#define DHCP_OPTION_LEASETIME     51
+
 		/** DHCP option list entry header, indicating that the DHCP message type constant will follow. */
 		#define DHCP_OPTION_MESSAGETYPE   53
 


### PR DESCRIPTION
The RNDIS ClassDriver and LowLevel Demo won't work on some Linux
hosts as their DHCP client requires the DHCP Option Lease Time.
Add it to both Demos. Tested on Fedora Linux 22.