### PR TITLE
[DO NOT MERGE YET] Fix HID Bootloader

### DIFF
--- a/Bootloaders/HID/BootloaderHID.c
+++ b/Bootloaders/HID/BootloaderHID.c
@@ -58,6 +58,11 @@ void Application_Jump_Check(void)
 	/* If the reset source was the bootloader and the key is correct, clear it and jump to the application */
 	if ((MCUSR & (1 << WDRF)) && (MagicBootKey == MAGIC_BOOT_KEY))
 	{
+		/* Turn off the watchdog */
+		MCUSR &= ~(1 << WDRF);
+		wdt_disable();
+
+		/* Clear the boot key and jump to the user application */
 		MagicBootKey = 0;
 
 		// cppcheck-suppress constStatement
@@ -97,6 +102,9 @@ static void SetupHardware(void)
 	/* Disable watchdog if enabled by bootloader/fuses */
 	MCUSR &= ~(1 << WDRF);
 	wdt_disable();
+
+	/* Disable clock division */
+	clock_prescale_set(clock_div_1);
 
 	/* Relocate the interrupt vector table to the bootloader section */
 	MCUCR = (1 << IVCE);

--- a/Bootloaders/HID/BootloaderHID.c
+++ b/Bootloaders/HID/BootloaderHID.c
@@ -146,14 +146,14 @@ void EVENT_USB_Device_ControlRequest(void)
 			while (!(Endpoint_IsOUTReceived()));
 
 			/* Read in the write destination address */
-			#if (FLASHEND > 0xFFFF)
+			#if (FLASHEND > USHRT_MAX)
 			uint32_t PageAddress = ((uint32_t)Endpoint_Read_16_LE() << 8);
 			#else
 			uint16_t PageAddress = Endpoint_Read_16_LE();
 			#endif
 
 			/* Check if the command is a program page command, or a start application command */
-			#if (FLASHEND > 0xFFFF)
+			#if (FLASHEND > USHRT_MAX)
 			if ((uint16_t)(PageAddress >> 8) == COMMAND_STARTAPPLICATION)
 			#else
 			if (PageAddress == COMMAND_STARTAPPLICATION)
@@ -161,7 +161,8 @@ void EVENT_USB_Device_ControlRequest(void)
 			{
 				RunBootloader = false;
 			}
-			else
+			// Do not overwrite the bootloader or write out of bounds
+			else if (PageAddress < BOOT_START_ADDR)
 			{
 				/* Erase the given FLASH page, ready to be programmed */
 				boot_page_erase(PageAddress);

--- a/Bootloaders/HID/BootloaderHID.h
+++ b/Bootloaders/HID/BootloaderHID.h
@@ -67,7 +67,5 @@
 		void Application_Jump_Check(void) ATTR_INIT_SECTION(3);
 
 		void EVENT_USB_Device_ConfigurationChanged(void);
-		void EVENT_USB_Device_UnhandledControlRequest(void);
 
 #endif
-

--- a/Bootloaders/HID/Descriptors.c
+++ b/Bootloaders/HID/Descriptors.c
@@ -110,7 +110,7 @@ const USB_Descriptor_Configuration_t ConfigurationDescriptor =
 		{
 			.Header                 = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
 
-			.InterfaceNumber        = INTERFACE_ID_Printer,
+			.InterfaceNumber        = INTERFACE_ID_GenericHID,
 			.AlternateSetting       = 0x00,
 
 			.TotalEndpoints         = 1,

--- a/Bootloaders/HID/Descriptors.h
+++ b/Bootloaders/HID/Descriptors.h
@@ -60,7 +60,7 @@
 		 */
 		enum InterfaceDescriptors_t
 		{
-			INTERFACE_ID_Printer = 0, /**< Printer interface descriptor ID */
+			INTERFACE_ID_GenericHID = 0, /**< GenericHID interface descriptor ID */
 		};
 
 	/* Macros: */

--- a/Bootloaders/HID/makefile
+++ b/Bootloaders/HID/makefile
@@ -20,7 +20,7 @@ OPTIMIZATION = s
 TARGET       = BootloaderHID
 SRC          = $(TARGET).c Descriptors.c $(LUFA_SRC_USB)
 LUFA_PATH    = ../../LUFA
-CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -IConfig/
+CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -IConfig/ -DBOOT_START_ADDR=$(BOOT_START_OFFSET)
 LD_FLAGS     = -Wl,--section-start=.text=$(BOOT_START_OFFSET)
 
 # Flash size and bootloader section sizes of the target, in KB. These must


### PR DESCRIPTION
Fixes #76

The clock divider is not essential, but I just added it as in the other bootloader sketch.

You could compact the code a bit more and more the check upwards and save the reg before. I just wanted to keep an better overview though.

See this for more information:
http://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html

Edit:
**Do not merge this PR yet. I will update a few more things and comment when its ready.**
