### PR TITLE
Fix USB_SetHIDReportItemInfo() function.

### DIFF
--- a/LUFA/Drivers/USB/Class/Common/HIDParser.c
+++ b/LUFA/Drivers/USB/Class/Common/HIDParser.c
@@ -364,8 +364,8 @@ void USB_SetHIDReportItemInfo(uint8_t* ReportData,
 
 	while (DataBitsRem--)
 	{
-		if (ReportItem->Value & (1 << (CurrentBit % 8)))
-		  ReportData[CurrentBit / 8] |= BitMask;
+		if (ReportItem->Value & BitMask)
+		  ReportData[CurrentBit / 8] |= (1 << (CurrentBit % 8));
 
 		CurrentBit++;
 		BitMask <<= 1;


### PR DESCRIPTION
Bits applying loop worked incorrect on large reports. Seems to me like a
copy/paste problem from USB_GetHIDReportItemInfo().