### PR TITLE
 Use PyUSB >= 1.0.0

### DIFF
--- a/Demos/Device/ClassDriver/GenericHID/HostTestApp/test_generic_hid_libusb.py
+++ b/Demos/Device/ClassDriver/GenericHID/HostTestApp/test_generic_hid_libusb.py
@@ -14,7 +14,7 @@
     pattern on the target board. Send and received report data is printed to
     the terminal.
 
-    Requires the PyUSB library (http://sourceforge.net/apps/trac/pyusb/).
+    Requires PyUSB >= 1.0.0 (https://github.com/pyusb/pyusb).
 """
 
 import sys
@@ -71,8 +71,8 @@ def main():
 
     print("Connected to device 0x%04X/0x%04X - %s [%s]" %
           (hid_device.idVendor, hid_device.idProduct,
-           usb.util.get_string(hid_device, 256, hid_device.iProduct),
-           usb.util.get_string(hid_device, 256, hid_device.iManufacturer)))
+           usb.util.get_string(hid_device, hid_device.iProduct),
+           usb.util.get_string(hid_device, hid_device.iManufacturer)))
 
     p = 0
     while (True):

--- a/Demos/Device/LowLevel/BulkVendor/HostTestApp/test_bulk_vendor.py
+++ b/Demos/Device/LowLevel/BulkVendor/HostTestApp/test_bulk_vendor.py
@@ -11,7 +11,7 @@
     receive a continuous stream of packets to/from to the device, to show
     bidirectional communications.
 
-    Requires the pyUSB library (http://sourceforge.net/projects/pyusb/).
+    Requires PyUSB >= 1.0.0 (https://github.com/pyusb/pyusb).
 """
 
 import sys
@@ -53,8 +53,8 @@ def main():
 
     print("Connected to device 0x%04X/0x%04X - %s [%s]" %
           (vendor_device.idVendor, vendor_device.idProduct,
-           usb.util.get_string(vendor_device, 255, vendor_device.iProduct),
-           usb.util.get_string(vendor_device, 255, vendor_device.iManufacturer)))
+           usb.util.get_string(vendor_device, vendor_device.iProduct),
+           usb.util.get_string(vendor_device, vendor_device.iManufacturer)))
 
     x = 0
     while 1:


### PR DESCRIPTION
All major package managers provide PyUSB versions >= 1.0.0 by default.
LUFA used an older, incompatible version, which lead to broken
BulkVendor and GenericHID demo applications for new users.

Also, update the PyUSB homepage URL as the old one is unreachable.

The incompatible change in `usb.util.get_string` was introduced in
https://github.com/pyusb/pyusb/commit/dac78933f6a6eaf5ae82f48e2f4e7d1733dc2f98