### PR TITLE
MassStorageBootloader: Fix lower nibble cluster update.

### DIFF
--- a/Bootloaders/MassStorage/Lib/VirtualFAT.c
+++ b/Bootloaders/MassStorage/Lib/VirtualFAT.c
@@ -260,7 +260,7 @@ static void UpdateFAT12ClusterEntry(uint8_t* const FATTable,
 	else
 	{
 		FATTable[FATOffset]     = ChainEntry;
-		FATTable[FATOffset + 1] = (FATTable[FATOffset] & 0xF0) | (ChainEntry >> 8);
+		FATTable[FATOffset + 1] = (FATTable[FATOffset + 1] & 0xF0) | (ChainEntry >> 8);
 	}
 }
 


### PR DESCRIPTION
Fixes an error when updating a cluster entry that uses the lower nibble of a FAT12 shared byte.