### PR TITLE
fix build failure with teensy-ee targets

### DIFF
--- a/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/makefile
+++ b/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/makefile
@@ -22,12 +22,12 @@ OBJECT_FILES = InputEEData.o
 all:
 
 # Determine the AVR sub-architecture of the build main application object file
-FIND_AVR_SUBARCH = avr$(shell avr-objdump -f $(TARGET).o | grep architecture | cut -d':' -f3 | cut -d',' -f1)
+FIND_AVR_SUBARCH = avr$(shell avr-objdump -f obj/$(TARGET).o | grep architecture | cut -d':' -f3 | cut -d',' -f1)
 
 # Create a linkable object file with the input binary EEPROM data stored in the FLASH section
-InputEEData.o: InputEEData.bin $(TARGET).o $(MAKEFILE_LIST)
+obj/InputEEData.o: obj/HID_EEPROM_Loader.o
 	@echo $(MSG_OBJCPY_CMD) Converting \"$<\" to a object file \"$@\"
-	avr-objcopy -I binary -O elf32-avr -B $(call FIND_AVR_SUBARCH) --rename-section .data=.progmem.data,contents,alloc,readonly,data $< $@
+	avr-objcopy -I binary -O elf32-avr -B $(call FIND_AVR_SUBARCH) --rename-section .data=.progmem.data,contents,alloc,readonly,data InputEEData.bin $@
 
 # Include LUFA build script makefiles
 include ../core.mk


### PR DESCRIPTION
Fixes https://github.com/abcminiuser/lufa/issues/164

Without patch:

```
$ cd Demos/Device/LowLevel/BulkVendor/
$ make clean
$ make MCU=at90usb1286 teensy-ee
<...>
 [OBJCPY]  : Extracting HEX file data from "BulkVendor.elf"
avr-objcopy -O ihex -R .eeprom -R .fuse -R .lock -R .signature BulkVendor.elf BulkVendor.hex
 [OBJCPY]  : Converting "BulkVendor.hex" to a binary file "InputEEData.bin"
avr-objcopy -I ihex -O binary BulkVendor.hex ../../../../LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/InputEEData.bin
 [MAKE]    : Making EEPROM loader application for "BulkVendor.hex"
make -s -C ../../../../LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/ MCU=at90usb1286 clean teensy
 [RM]      : Removing object files of "HID_EEPROM_Loader"
 [RM]      : Removing dependency files of "HID_EEPROM_Loader"
 [RM]      : Removing output files of "HID_EEPROM_Loader"
make[1]: *** No rule to make target 'obj/InputEEData.o', needed by 'HID_EEPROM_Loader.elf'.  Stop.
make: *** [../../../../LUFA/Build/DMBS/DMBS/hid.mk:55: teensy-ee] Error 2
```

With patch:

```
$ cd Demos/Device/LowLevel/BulkVendor/
$ make clean
$ make MCU=at90usb1286 teensy-ee
 [OBJCPY]  : Converting "BulkVendor.hex" to a binary file "InputEEData.bin"
avr-objcopy -I ihex -O binary BulkVendor.hex ../../../../LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/InputEEData.bin
 [MAKE]    : Making EEPROM loader application for "BulkVendor.hex"
make -s -C ../../../../LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/ MCU=at90usb1286 clean teensy
 [RM]      : Removing object files of "HID_EEPROM_Loader"
 [RM]      : Removing dependency files of "HID_EEPROM_Loader"
 [RM]      : Removing output files of "HID_EEPROM_Loader"
 [GCC]     : Compiling C file "HID_EEPROM_Loader.c"
 [OBJCPY]  : Converting "obj/HID_EEPROM_Loader.o" to a object file "obj/InputEEData.o"
 [LNK]     : Linking object files into "HID_EEPROM_Loader.elf"
 [OBJCPY]  : Extracting HEX file data from "HID_EEPROM_Loader.elf"
 [HID]     : Programming FLASH with teensy_loader_cli using "HID_EEPROM_Loader.hex"
Teensy Loader, Command Line, Version 2.1
Read "HID_EEPROM_Loader.hex": 3338 bytes, 2.6% usage
```