### PR TITLE
Fix BootloaderCDC flashing over 32k

### DIFF
--- a/Bootloaders/CDC/BootloaderCDC.c
+++ b/Bootloaders/CDC/BootloaderCDC.c
@@ -475,8 +475,8 @@ static void CDC_Task(void)
 	else if (Command == AVR109_COMMAND_SetCurrentAddress)
 	{
 		/* Set the current address to that given by the host (translate 16-bit word address to byte address) */
-		CurrAddress   = (FetchNextCommandByte() << 9);
-		CurrAddress  |= (FetchNextCommandByte() << 1);
+		CurrAddress   = ((uint32_t)FetchNextCommandByte() << 9);
+		CurrAddress  |= ((uint32_t)FetchNextCommandByte() << 1);
 
 		/* Send confirmation byte back to the host */
 		WriteNextResponseByte('\r');


### PR DESCRIPTION
When loading the bytes from the USB serial stream that represent the current position in words, BootloaderCDC uses a trick which is too clever for GCC in order to populate a u32 and double the integer value.

In my testing, when the size of the flashed item exceeds 32k, the asm generated by avr-gcc (both v5 and v10) incorrectly manipulates the u32, leading to its upper 2 bytes being set to 0xFF. This then fails the `Address < BOOT_START_ADDR` test in `IsPageAddressValid`.

This PR adds an explicit u32 cast to the function calls, leading to avr-gcc treating the u32 correctly and populating all 4 bytes.

Disclaimer: I am not familiar with AVR ASM and have based this on functional testing as well as an approximate analysis.