### PR TITLE
HTML corrections in doxygen source

### DIFF
--- a/Demos/Device/ClassDriver/CCID/CCID.txt
+++ b/Demos/Device/ClassDriver/CCID/CCID.txt
@@ -31,10 +31,11 @@
  *    <td><b>USB Class:</b></td>
  *    <td>CCID Class</td>
  *   </tr>
-  *   <tr>
+ *   <tr>
  *    <td><b>USB Subclass:</b></td>
  *    <td>None</td>
  *   </tr>
+ *   <tr>
  *    <td><b>Relevant Standards:</b></td>
  *    <td>USB CCID 1.1 Specification for Integrated Circuit(s) Cards Interface Devices</td>
  *    <td>ISO 7816-3</td>

--- a/Demos/Device/ClassDriver/MassStorageKeyboard/MassStorageKeyboard.txt
+++ b/Demos/Device/ClassDriver/MassStorageKeyboard/MassStorageKeyboard.txt
@@ -96,5 +96,6 @@
  *    <td>AppConfig.h</td>
  *    <td>Configuration define, indicating if the disk should be write protected or not.</td>
  *   </tr>
+ *  </table>
  */
 

--- a/Demos/Device/ClassDriver/VirtualSerialMassStorage/VirtualSerialMassStorage.txt
+++ b/Demos/Device/ClassDriver/VirtualSerialMassStorage/VirtualSerialMassStorage.txt
@@ -89,5 +89,6 @@
  *    <td>AppConfig.h</td>
  *    <td>Configuration define, indicating if the disk should be write protected or not.</td>
  *   </tr>
+ *  </table>
  */
 

--- a/Demos/Device/LowLevel/CCID/CCID.txt
+++ b/Demos/Device/LowLevel/CCID/CCID.txt
@@ -35,6 +35,7 @@
  *    <td><b>USB Subclass:</b></td>
  *    <td>None</td>
  *   </tr>
+ *   <tr>
  *    <td><b>Relevant Standards:</b></td>
  *    <td>USB CCID 1.1 Specification for Integrated Circuit(s) Cards Interface Devices</td>
  *    <td>ISO 7816-3</td>


### PR DESCRIPTION
`doxygen` will not generate the documentation without the fixes in this pull request.  The fixes address missing HTML tags.